### PR TITLE
The threadId must be an unsigned 16 bit

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
@@ -62,8 +62,8 @@ public enum OSXJNAAffinity implements IAffinity {
         final CLibrary lib = CLibrary.INSTANCE;
         int tid = CLibrary.INSTANCE.pthread_self();
         //The tid must be an unsigned 16 bit
-        short s_tid = (short)tid;
-        return s_tid;
+        int tid_16 = (int) tid & 0xFFFF;
+        return tid_16;
     }
 
     interface CLibrary extends Library {


### PR DESCRIPTION
The threadId() is must return an unsigned 16 bit.

The VanillaChroncileTest now passes on my Mac.
