### PR TITLE
Remove logging from LinuxHelper, update versions

### DIFF
--- a/affinity-test/pom.xml
+++ b/affinity-test/pom.xml
@@ -24,14 +24,14 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
         <relativePath/>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>affinity-test</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>OpenHFT/Java-Thread-Affinity/affinity-test</name>
@@ -43,7 +43,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.6</version>
+                <version>3.4.10</version>
                 <scope>import</scope>
             </dependency>
             <dependency>
@@ -124,29 +124,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${openhft.java.version}</source>
-                    <target>${openhft.java.version}</target>
-                    <encoding>UTF-8</encoding>
-                    <verbose>true</verbose>
-                    <fork>true</fork>
-                    <executable>${openhft.java.home}/bin/javac</executable>
-                    <compilerVersion>${openhft.java.version}</compilerVersion>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <jvm>${openhft.java.home}/bin/java</jvm>
-                    <systemPropertyVariables>
-                        <main.basedir>${project.basedir}</main.basedir>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
             <!--
                 generate maven dependencies versions file that can be used later
                 to install the right bundle in test phase.
@@ -201,60 +178,8 @@
     </build>
 
     <scm>
-        <url>scm:git:https://github.com/OpenHFT/Java-Lang.git</url>
+        <url>scm:git:https://github.com/OpenHFT/Java-Thread-Affinity.git</url>
     </scm>
-
-    <!-- ******************************************************************* -->
-    <!-- PROFILES                                                            -->
-    <!-- ******************************************************************* -->
-
-    <profiles>
-
-        <profile>
-            <id>jdk_default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <openhft.java.home>${env.JAVA_HOME}</openhft.java.home>
-                <openhft.java.version>1.6</openhft.java.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>jdk_6</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <openhft.java.home>${env.JAVA_HOME_6}</openhft.java.home>
-                <openhft.java.version>1.6</openhft.java.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>jdk_7</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <openhft.java.home>${env.JAVA_HOME_7}</openhft.java.home>
-                <openhft.java.version>1.7</openhft.java.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>jdk_8</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <openhft.java.home>${env.JAVA_HOME_8}</openhft.java.home>
-                <openhft.java.version>1.7</openhft.java.version>
-            </properties>
-        </profile>
-
-    </profiles>
 
 </project>
 

--- a/affinity/pom.xml
+++ b/affinity/pom.xml
@@ -44,7 +44,7 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.4.8</version>
+                <version>3.4.10</version>
                 <scope>import</scope>
             </dependency>
         </dependencies>
@@ -57,17 +57,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
         </dependency>
-
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.kohsuke.jetbrains</groupId>
             <artifactId>annotations</artifactId>
@@ -78,13 +75,11 @@
             <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/affinity/src/main/java/net/openhft/affinity/impl/LinuxHelper.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/LinuxHelper.java
@@ -3,14 +3,11 @@ package net.openhft.affinity.impl;
 import com.sun.jna.*;
 import com.sun.jna.ptr.IntByReference;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class LinuxHelper {
-    private static final Logger logger = LoggerFactory.getLogger(LinuxHelper.class);
     private static final String LIBRARY_NAME = "c";
     private static final VersionHelper UNKNOWN = new VersionHelper(0,0,0);
     private static final VersionHelper VERSION_2_6 = new VersionHelper(2,6,0);
@@ -114,11 +111,11 @@ public class LinuxHelper {
         try {
             if(CLibrary.INSTANCE.uname(uname) == 0) {
                 ver = new VersionHelper(uname.getRealeaseVersion());
-                logger.info("uname: " + uname);
             }
         } catch(Throwable e) {
-            logger.warn("Failed to determine Linux version: " + e);
+            //logger.warn("Failed to determine Linux version: " + e);
         }
+
         version = ver;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>root-parent-pom</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath/>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>Java-Thread-Affinity</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Java Affinity Parent</name>


### PR DESCRIPTION
Logging in LinuxHelper causes Chronicle-Logger to crash as it invoke the logger while the logger is starting up.
