### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/impl/Utilities.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/Utilities.java
@@ -7,7 +7,10 @@ import java.util.BitSet;
 /**
  * Created by andre on 20/06/15.
  */
-public class Utilities {
+public final class Utilities {
+    private Utilities() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
     /**
      * Creates a hexademical representation of the bit set
      *

--- a/affinity/src/main/java/net/openhft/ticker/Ticker.java
+++ b/affinity/src/main/java/net/openhft/ticker/Ticker.java
@@ -35,6 +35,10 @@ public final class Ticker {
         }
     }
 
+    private Ticker() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
     /**
      * @return The current value of the system timer, in nanoseconds.
      */

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockBindMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockBindMain.java
@@ -21,7 +21,11 @@ import static net.openhft.affinity.AffinityStrategies.*;
 /**
  * @author peter.lawrey
  */
-public class AffinityLockBindMain {
+public final class AffinityLockBindMain {
+    private AffinityLockBindMain() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
     public static void main(String... args) throws InterruptedException {
         AffinityLock al = AffinityLock.acquireLock();
         try {

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockMain.java
@@ -19,7 +19,11 @@ package net.openhft.affinity;
 /**
  * @author peter.lawrey
  */
-public class AffinityLockMain {
+public final class AffinityLockMain {
+    private AffinityLockMain() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
     public static void main(String... args) throws InterruptedException {
         AffinityLock al = AffinityLock.acquireLock();
         try {

--- a/affinity/src/test/java/net/openhft/affinity/AffinitySupportMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinitySupportMain.java
@@ -19,7 +19,11 @@ package net.openhft.affinity;
 /**
  * @author peter.lawrey
  */
-public class AffinitySupportMain {
+public final class AffinitySupportMain {
+    private AffinitySupportMain() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
     public static void main(String... args) {
         AffinityLock al = AffinityLock.acquireLock();
         try {

--- a/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryMain.java
@@ -26,10 +26,13 @@ import static net.openhft.affinity.AffinityStrategies.*;
 /**
  * @author peter.lawrey
  */
-public class AffinityThreadFactoryMain {
+public final class AffinityThreadFactoryMain {
     private static final ExecutorService ES = Executors.newFixedThreadPool(4,
             new AffinityThreadFactory("bg", SAME_CORE, DIFFERENT_SOCKET, ANY));
 
+    private AffinityThreadFactoryMain(){
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
     public static void main(String... args) throws InterruptedException {
         for (int i = 0; i < 12; i++)
             ES.submit(new Callable<Void>() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here:  https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat