### PR TITLE
fix last cpu not being marked reservable

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -123,7 +123,7 @@ public class AffinityLock implements Closeable {
                 LoggerFactory.getLogger(AffinityLock.class).info("No isolated CPUs found, so assuming CPUs 1 to {} available.", (PROCESSORS - 1));
                 reserverable = new BitSet(PROCESSORS);
                 // make the first CPU unavailable
-                reserverable.set(1, PROCESSORS - 1, true);
+                reserverable.set(1, PROCESSORS, true);
                 reserverable.set(0, false);
                 return reserverable;
             }


### PR DESCRIPTION
not sure how this was never spotted (maybe everyone is using isolated CPUs instead) but it seems pretty obvious that the last CPU is never marked reservable. this is because java.util.BitSet.set() takes an exclusive upper index bound, and so the AffinityLock code appears to be off-by-one, unless I am missing some reason the highest CPU shouldn't have been reservable..

the lowest, CPU 0, is still correctly being marked unreservable.

notice in the following logs, that while "CPUs 1 to 3" are available, threads are only assigned to two of them.

INFO  [2018-08-31 04:44:07,303] net.openhft.affinity.AffinityLock: No isolated CPUs found, so assuming CPUs 1 to 3 available.
INFO  [2018-08-31 04:44:07,315] net.openhft.affinity.LockInventory: Assigning core 2: cpus 2 to Thread[Thread-15,5,main]
INFO  [2018-08-31 04:44:07,316] net.openhft.affinity.LockInventory: Assigning core 1: cpus 1 to Thread[Thread-17,5,main]
WARN  [2018-08-31 04:44:07,316] net.openhft.affinity.LockInventory: No reservable Core for Thread[Thread-16,5,main]
WARN  [2018-08-31 04:44:07,317] net.openhft.affinity.LockInventory: No reservable CPU for Thread[Thread-16,5,main]
