### PR TITLE
Fix for FileLockBasedLockChecker attempting to release unreserved locks

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -322,10 +322,12 @@ public class AffinityLock implements Closeable {
 
     final boolean canReserve(boolean specified) {
 
+        if (!specified && !reservable)
+            return false;
+
         if (!LockCheck.isCpuFree(cpuId))
             return false;
 
-        if (!specified && !reservable) return false;
         if (assignedThread != null) {
             if (assignedThread.isAlive()) {
                 return false;


### PR DESCRIPTION
Fix for #63 FileLockBasedLockChecker attempting to release locks held by other affinity-enabled processes