### PR TITLE
fixed NumberFormatException when core 63 was used in -Daffinity.reserved 

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -133,9 +133,13 @@ public class AffinityLock implements Closeable {
         long[] longs = new long[1 + (reservedAffinity.length() - 1) / 16];
         int end = reservedAffinity.length();
         for(int i = 0; i < longs.length ; i++) {
-            int begin = Math.max(0, end - 16);
-            longs[i] = Long.parseLong(reservedAffinity.substring(begin, end), 16);
-            end = begin;
+            if(end < 16) {
+                longs[i] = Long.parseLong(reservedAffinity.substring(0, end), 16);
+            } else {
+                longs[i] = Long.parseLong(reservedAffinity.substring(end - 16, end - 8), 16) << 32L;
+                longs[i] |= Long.parseLong(reservedAffinity.substring(end - 8, end), 16);
+                end -= 16;
+            }
         }
         return BitSet.valueOf(longs);
     }


### PR DESCRIPTION
The fix for using -Daffinity.reserved with more than 64 core (#68) has an issue : to compute the bitset representing that mask, it uses under the hood Long.parseLong(substring, 16) where substring is at most 16 hexadecimal digits. Unfortunately, if the highest bit is set (so if core 63 is selected in the mask), it will cause a NumberFormatException because there is an overflow (because Java types are all signed).

This PR fixes that by splitting the parsing into 2 ints and combining them into a long