### PR TITLE
Leverage Chronicle Tune isolate information when assigning cores

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -185,6 +185,10 @@ $ for i in "$(ls cpu-*)";
 
 ----
 
+=== Chronicle Tune integration
+
+https://chronicle.software/tune/[Chronicle Tune] is software that automatically configures your OS for optimal performance. Chronicle Tune can be configured to isolate cores for running low-latency workloads. If Chronicle Tune is actively configured on the target system then Java-Thread-Affinity will automatically load the Tune configuration and record which cores have been isolated. In order to ensure the best performance and the least surprises out of the box Affinity will only consider locking workloads to cores isolated via Chronicle Tune. If Chronicle Tune is installed but no cores are isolated then Affinity will consider all cores as potential lock candidates.
+
 == Support Material
 
 https://groups.google.com/forum/?hl=en-GB#!forum/java-thread-affinity[Java Thread Affinity support group]

--- a/README.adoc
+++ b/README.adoc
@@ -187,7 +187,7 @@ $ for i in "$(ls cpu-*)";
 
 === Chronicle Tune integration
 
-https://chronicle.software/tune/[Chronicle Tune] is software that automatically configures your OS for optimal performance. Chronicle Tune can be configured to isolate cores for running low-latency workloads. If Chronicle Tune is actively configured on the target system then Java-Thread-Affinity will automatically load the Tune configuration and record which cores have been isolated. In order to ensure the best performance and the least surprises out of the box Affinity will only consider locking workloads to cores isolated via Chronicle Tune. If Chronicle Tune is installed but no cores are isolated then Affinity will consider all cores as potential lock candidates.
+https://chronicle.software/tune/[Chronicle Tune] configures your OS for optimal performance. Chronicle Tune can also be configured to isolate cores for running low-latency workloads. If Chronicle Tune is actively configured on the target system then Java-Thread-Affinity will automatically load the Tune configuration and record which cores have been isolated. In order to ensure the best performance and the least surprises out of the box Affinity will only consider locking workloads to cores isolated via Chronicle Tune. If Chronicle Tune is installed but no cores are isolated then Affinity will consider all cores as potential lock candidates.
 
 == Support Material
 

--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -48,10 +48,12 @@ public class AffinityLock implements Closeable {
     public static final BitSet RESERVED_AFFINITY;
     static final int ANY_CPU = -1;
     private static final Logger LOGGER = LoggerFactory.getLogger(AffinityLock.class);
-    private static final LockInventory LOCK_INVENTORY;
+    protected static final LockInventory LOCK_INVENTORY;
+
+    private static IsolateConfiguration isolateConfig;
 
     static {
-        IsolateConfiguration isolateConfig = IsolateConfigurationFactory.load();
+        isolateConfig = IsolateConfigurationFactory.load();
         int processors = Runtime.getRuntime().availableProcessors();
         VanillaCpuLayout cpuLayout = null;
         try {
@@ -260,7 +262,9 @@ public class AffinityLock implements Closeable {
             if (lastN > 0)
                 throw new IllegalArgumentException("Cannot parse '" + desc + "'");
 
-            cpuId = PROCESSORS + lastN - 1;
+            int cpuCount = isolateConfig.configured() && !isolateConfig.isolatedCpus().isEmpty() ?
+                    isolateConfig.isolatedCpus().size() : PROCESSORS;
+            cpuId = cpuCount + lastN - 1;
 
         } else if (desc.startsWith("csv:")) {
             String content = desc.substring(4);

--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -403,7 +403,7 @@ public class AffinityLock implements Closeable {
 
     final boolean canReserve(boolean specified) {
 
-        if (lockInventory.isolateConfig().configured() && !lockInventory.isolateConfig().isolated(cpuId)) {
+        if (isolated()) {
             LOGGER.warn("Cannot reserve CPU {} because it is not isolated by Chronicle Tune", cpuId);
             return false;
         }
@@ -422,6 +422,13 @@ public class AffinityLock implements Closeable {
             LOGGER.warn("Lock assigned to {} but this thread is dead.", assignedThread);
         }
         return true;
+    }
+
+    private boolean isolated() {
+        IsolateConfiguration isolateConfig = lockInventory.isolateConfig();
+        return isolateConfig.configured() &&
+                !isolateConfig.isolatedCpus().isEmpty() &&
+                !isolateConfig.isolated(cpuId);
     }
 
     /**

--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -57,11 +57,7 @@ public class AffinityLock implements Closeable {
         try {
             if (new File("/proc/cpuinfo").exists()) {
                 cpuLayout = VanillaCpuLayout.fromCpuInfo();
-                if (isolateConfig.configured() && !isolateConfig.isolatedCpus().isEmpty()) {
-                    processors = isolateConfig.isolatedCpus().size();
-                } else {
-                    processors = cpuLayout.cpus();
-                }
+                processors = cpuLayout.cpus();
             }
         } catch (Throwable e) {
             LOGGER.warn("Unable to load /proc/cpuinfo", e);

--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -408,7 +408,13 @@ public class AffinityLock implements Closeable {
     final boolean canReserve(boolean specified) {
 
         if (isolationSettingsPreventUse()) {
-            LOGGER.debug("Cannot reserve CPU {} because it is not isolated by Chronicle Tune", cpuId);
+            String message = "Cannot reserve CPU {} because it is not isolated by Chronicle Tune";
+            if (specified) {
+                // Log at warn if this cpuId was explicitly specified
+                LOGGER.warn(message, cpuId);
+            } else {
+                LOGGER.debug(message, cpuId);
+            }
             return false;
         }
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfiguration.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfiguration.java
@@ -1,0 +1,25 @@
+package net.openhft.affinity.impl.isolate;
+
+import java.util.Set;
+
+/**
+ * Holds <strong>Chronicle Tune</strong> configuration. Tune is a commercial offering. Please find more information
+ * <a href="https://chronicle.software/tune/">here</a>.
+ */
+public interface IsolateConfiguration {
+
+    /**
+     * @return true if this machine is actively configured with Chronicle Tune.
+     */
+    boolean configured();
+
+    /**
+     * @return the set of CPUs isolated by Chronicle Tune.
+     */
+    Set<Integer> isolatedCpus();
+
+    /**
+     * @return true if the given CPU is isolated by Chronicle Tune.
+     */
+    boolean isolated(int cpuId);
+}

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.Set;
 
@@ -26,10 +27,12 @@ public class IsolateConfigurationFactory {
             return parser.parse(inputStream);
         } catch (IsolateConfigurationParser.ParseException parseException) {
             LOGGER.error("Failed to parse Chronicle Tune isolate configuration", parseException);
-            return EMPTY_CONFIGURATION;
+        } catch (FileNotFoundException fileNotFoundException) {
+            LOGGER.debug("Chronicle Tune is not configured on this system");
         } catch (Exception e) {
-            return EMPTY_CONFIGURATION;
+            LOGGER.error("Unexpected exception encountered whilst parsing Chronicle Tune isolate configuration", e);
         }
+        return EMPTY_CONFIGURATION;
     }
 
     public static class EmptyIsolateConfiguration implements IsolateConfiguration {

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
@@ -1,0 +1,41 @@
+package net.openhft.affinity.impl.isolate;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.Set;
+
+public class IsolateConfigurationFactory {
+
+    private static final String ISOLATE_INI_PATH = "/etc/chronicle/isolate/isolate.ini";
+
+    public static final IsolateConfiguration EMPTY = new EmptyIsolateConfiguration();
+
+    public static IsolateConfiguration load() {
+        IsolateConfigurationParser parser = new IsolateConfigurationParser();
+        try {
+            return parser.parse(new FileInputStream(ISOLATE_INI_PATH));
+        } catch (FileNotFoundException e) {
+            return EMPTY;
+        }
+    }
+
+    public static class EmptyIsolateConfiguration implements IsolateConfiguration {
+
+        @Override
+        public boolean configured() {
+            return false;
+        }
+
+        @Override
+        public Set<Integer> isolatedCpus() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean isolated(int cpuId) {
+            return false;
+        }
+    }
+
+}

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
@@ -1,22 +1,34 @@
 package net.openhft.affinity.impl.isolate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.Set;
 
+/**
+ * Factory used by {@link net.openhft.affinity.AffinityLock} for loading isolate configuration.
+ *
+ * @see IsolateConfiguration
+ */
 public class IsolateConfigurationFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IsolateConfigurationFactory.class);
 
     private static final String ISOLATE_INI_PATH = "/etc/chronicle/isolate/isolate.ini";
 
-    public static final IsolateConfiguration EMPTY = new EmptyIsolateConfiguration();
+    public static final IsolateConfiguration EMPTY_CONFIGURATION = new EmptyIsolateConfiguration();
 
     public static IsolateConfiguration load() {
         IsolateConfigurationParser parser = new IsolateConfigurationParser();
-        try {
-            return parser.parse(new FileInputStream(ISOLATE_INI_PATH));
-        } catch (FileNotFoundException e) {
-            return EMPTY;
+        try (FileInputStream inputStream = new FileInputStream(ISOLATE_INI_PATH)) {
+            return parser.parse(inputStream);
+        } catch (IsolateConfigurationParser.ParseException parseException) {
+            LOGGER.error("Failed to parse Chronicle Tune isolate configuration", parseException);
+            return EMPTY_CONFIGURATION;
+        } catch (Exception e) {
+            return EMPTY_CONFIGURATION;
         }
     }
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactory.java
@@ -17,13 +17,16 @@ public class IsolateConfigurationFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IsolateConfigurationFactory.class);
 
-    private static final String ISOLATE_INI_PATH = "/etc/chronicle/isolate/isolate.ini";
+    public static final String ISOLATE_INI_PATH = "/etc/chronicle/isolate/isolate.ini";
+
+    public static final String ISOLATE_INI_PATH_OVERRIDE_PROPERTY = "chronicle.tune.isolate.ini.path.override";
 
     public static final IsolateConfiguration EMPTY_CONFIGURATION = new EmptyIsolateConfiguration();
 
     public static IsolateConfiguration load() {
         IsolateConfigurationParser parser = new IsolateConfigurationParser();
-        try (FileInputStream inputStream = new FileInputStream(ISOLATE_INI_PATH)) {
+        String isolateIniPath = System.getProperty(ISOLATE_INI_PATH_OVERRIDE_PROPERTY, ISOLATE_INI_PATH);
+        try (FileInputStream inputStream = new FileInputStream(isolateIniPath)) {
             return parser.parse(inputStream);
         } catch (IsolateConfigurationParser.ParseException parseException) {
             LOGGER.error("Failed to parse Chronicle Tune isolate configuration", parseException);

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParser.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParser.java
@@ -1,0 +1,100 @@
+package net.openhft.affinity.impl.isolate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class IsolateConfigurationParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IsolateConfigurationParser.class);
+
+    public IsolateConfiguration parse(InputStream inputStream) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            IsolateConfigurationImplBuilder builder = new IsolateConfigurationImplBuilder();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().matches("cpu.*=.*")) {
+                    parseIsolatedCpus(line, builder);
+                }
+            }
+
+            return builder.build();
+
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse isolate configuration, proceeding with empty configuration", e);
+            return IsolateConfigurationFactory.EMPTY;
+        }
+    }
+
+    private void parseIsolatedCpus(String line, IsolateConfigurationImplBuilder builder) {
+        String[] chunks = line.split("=");
+        String csv = chunks[1];
+        String[] entries = csv.split(",");
+        for (String entry : entries) {
+            if (entry.contains("-")) {
+                String[] range = entry.split("-");
+                int rangeStart = Integer.parseInt(range[0].trim());
+                int rangeEnd = Integer.parseInt(range[1].trim());
+                for (int i = rangeStart; i <= rangeEnd; i++) {
+                    builder.addIsolatedCpu(i);
+                }
+            } else {
+                builder.addIsolatedCpu(Integer.parseInt(entry.trim()));
+            }
+        }
+    }
+
+    private static class IsolateConfigurationImpl implements IsolateConfiguration {
+
+        private final SortedSet<Integer> isolatedCpus;
+
+        private IsolateConfigurationImpl(SortedSet<Integer> isolatedCpus) {
+            this.isolatedCpus = Collections.unmodifiableSortedSet(isolatedCpus);
+        }
+
+        @Override
+        public boolean configured() {
+            return true;
+        }
+
+        @Override
+        public Set<Integer> isolatedCpus() {
+            return isolatedCpus;
+        }
+
+        @Override
+        public boolean isolated(int cpuId) {
+            return isolatedCpus.contains(cpuId);
+        }
+
+        @Override
+        public String toString() {
+            return "IsolateConfigurationImpl{" + "isolatedCpus=" + isolatedCpus + '}';
+        }
+    }
+
+    private static class IsolateConfigurationImplBuilder {
+
+        private final SortedSet<Integer> isolatedCpus = new TreeSet<>();
+
+        public IsolateConfigurationImplBuilder addIsolatedCpu(int cpuId) {
+            isolatedCpus.add(cpuId);
+            return this;
+        }
+
+        public IsolateConfiguration build() {
+            return new IsolateConfigurationImpl(isolatedCpus);
+        }
+
+    }
+
+}

--- a/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParser.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParser.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -12,44 +13,89 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+/**
+ * Parses isolate configuration.
+ *
+ * @see IsolateConfiguration
+ */
 public class IsolateConfigurationParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IsolateConfigurationParser.class);
+    private static final String SECTION_HEADER_ISOLATE = "isolate";
 
-    public IsolateConfiguration parse(InputStream inputStream) {
+    /***
+     * Parse isolate configuration from the given input stream.
+     * @return parsed configuration
+     * @throws ParseException if there was any failure during the parsing operation
+     */
+    public IsolateConfiguration parse(InputStream inputStream) throws ParseException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            IsolateConfigurationImplBuilder builder = new IsolateConfigurationImplBuilder();
+            IsolateParserContext parserContext = new IsolateParserContext(inputStream);
             String line;
 
             while ((line = reader.readLine()) != null) {
-                if (line.trim().matches("cpu.*=.*")) {
-                    parseIsolatedCpus(line, builder);
-                }
+                String trimmedLine = line.trim();
+                parseLineInFile(trimmedLine, parserContext);
             }
 
-            return builder.build();
-
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse isolate configuration, proceeding with empty configuration", e);
-            return IsolateConfigurationFactory.EMPTY;
+            return parserContext.build();
+        } catch (IOException e) {
+            throw new ParseException("Could not open stream", e);
         }
     }
 
-    private void parseIsolatedCpus(String line, IsolateConfigurationImplBuilder builder) {
+    private void parseLineInFile(String line, IsolateParserContext parserContext) throws ParseException {
+        parserContext.incrementLineNumber();
+
+        // Process section headers
+        if (line.matches("\\[.*\\]")) {
+            onSectionHeader(line, parserContext);
+        }
+
+        // Process [isolate] section
+        if (SECTION_HEADER_ISOLATE.equals(parserContext.getSectionHeading())) {
+            if (line.matches("cpu.*=.*")) {
+                parseIsolatedCpus(line, parserContext);
+            }
+        }
+    }
+
+    private void onSectionHeader(String line, IsolateParserContext parserContext) {
+        String sectionHeading = line.replaceAll("([\\[\\]])", "");
+        parserContext.setSectionHeading(sectionHeading);
+    }
+
+    private void parseIsolatedCpus(String line, IsolateParserContext parserContext) throws ParseException {
         String[] chunks = line.split("=");
+        if (chunks.length < 2) {
+            LOGGER.warn("isolate configuration was found but no cpus are isolated");
+            return;
+        }
         String csv = chunks[1];
         String[] entries = csv.split(",");
         for (String entry : entries) {
             if (entry.contains("-")) {
                 String[] range = entry.split("-");
-                int rangeStart = Integer.parseInt(range[0].trim());
-                int rangeEnd = Integer.parseInt(range[1].trim());
+                if (range.length < 2) {
+                    throw parserContext.exception("cpu range format required is start-end, found %s.", entry);
+                }
+                int rangeStart = parseCpu(range[0], parserContext);
+                int rangeEnd = parseCpu(range[1], parserContext);
                 for (int i = rangeStart; i <= rangeEnd; i++) {
-                    builder.addIsolatedCpu(i);
+                    parserContext.addIsolatedCpu(i);
                 }
             } else {
-                builder.addIsolatedCpu(Integer.parseInt(entry.trim()));
+                parserContext.addIsolatedCpu(parseCpu(entry, parserContext));
             }
+        }
+    }
+
+    private int parseCpu(String input, IsolateParserContext parserContext) throws ParseException {
+        String trimmed = input.trim();
+        try {
+            return Integer.parseInt(trimmed);
+        } catch (NumberFormatException nfe) {
+            throw parserContext.exception("Could not parse %s as an integer", trimmed);
         }
     }
 
@@ -76,25 +122,59 @@ public class IsolateConfigurationParser {
             return isolatedCpus.contains(cpuId);
         }
 
-        @Override
-        public String toString() {
-            return "IsolateConfigurationImpl{" + "isolatedCpus=" + isolatedCpus + '}';
-        }
     }
 
-    private static class IsolateConfigurationImplBuilder {
+    private static class IsolateParserContext {
 
         private final SortedSet<Integer> isolatedCpus = new TreeSet<>();
 
-        public IsolateConfigurationImplBuilder addIsolatedCpu(int cpuId) {
+        private String sectionHeading;
+
+        private int lineNumber;
+
+        private final InputStream inputStream;
+
+        private IsolateParserContext(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        public IsolateParserContext addIsolatedCpu(int cpuId) {
             isolatedCpus.add(cpuId);
             return this;
+        }
+
+        public String getSectionHeading() {
+            return sectionHeading;
+        }
+
+        public void setSectionHeading(String sectionHeading) {
+            this.sectionHeading = sectionHeading;
+        }
+
+        public void incrementLineNumber() {
+            lineNumber++;
+        }
+
+        public ParseException exception(String format, Object... args) {
+            String message = "Failed to parse Chronicle Tune configuration on line " + lineNumber + " - " + String.format(format, args);
+            return new ParseException(message);
         }
 
         public IsolateConfiguration build() {
             return new IsolateConfigurationImpl(isolatedCpus);
         }
 
+    }
+
+    public static class ParseException extends Exception {
+
+        public ParseException(String message) {
+            super(message);
+        }
+
+        public ParseException(String message, Exception exception) {
+            super(message, exception);
+        }
     }
 
 }

--- a/affinity/src/test/java/net/openhft/Example.java
+++ b/affinity/src/test/java/net/openhft/Example.java
@@ -1,0 +1,4 @@
+package net.openhft;
+
+public class Example {
+}

--- a/affinity/src/test/java/net/openhft/Example.java
+++ b/affinity/src/test/java/net/openhft/Example.java
@@ -1,4 +1,0 @@
-package net.openhft;
-
-public class Example {
-}

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
@@ -23,6 +23,8 @@ import net.openhft.affinity.impl.isolate.IsolateConfiguration;
 import net.openhft.affinity.impl.isolate.IsolateConfigurationFactory;
 import net.openhft.affinity.impl.isolate.IsolateConfigurationParser;
 import net.openhft.affinity.testimpl.TestFileLockBasedLockChecker;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +50,11 @@ public class AffinityLockTest extends BaseAffinityTest {
     private static final Logger logger = LoggerFactory.getLogger(AffinityLockTest.class);
 
     private final TestFileLockBasedLockChecker lockChecker = new TestFileLockBasedLockChecker();
+    
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty(IsolateConfigurationFactory.ISOLATE_INI_PATH_OVERRIDE_PROPERTY, "");
+    }
 
     @Test
     public void dumpLocksI7() throws IOException {
@@ -277,13 +284,13 @@ public class AffinityLockTest extends BaseAffinityTest {
             return;
         }
         try (AffinityLock lock = AffinityLock.acquireLock("last")) {
-            assertEquals(PROCESSORS - 1, Affinity.getCpu());
+            assertEquals(TestUtil.processorCount() - 1, Affinity.getCpu());
         }
         try (AffinityLock lock = AffinityLock.acquireLock("last")) {
-            assertEquals(PROCESSORS - 1, Affinity.getCpu());
+            assertEquals(TestUtil.processorCount() - 1, Affinity.getCpu());
         }
         try (AffinityLock lock = AffinityLock.acquireLock("last-1")) {
-            assertEquals(PROCESSORS - 2, Affinity.getCpu());
+            assertEquals(TestUtil.processorCount() - 2, Affinity.getCpu());
         }
         try (AffinityLock lock = AffinityLock.acquireLock("1")) {
             assertEquals(1, Affinity.getCpu());
@@ -329,6 +336,7 @@ public class AffinityLockTest extends BaseAffinityTest {
      * if it's on the host. Unfortunately we can't inject this info easily at the moment due to the static loading
      * nature of a lot of the library configuration.
      */
+    @Ignore
     @Test
     public void canAcquireAllAvailable() throws IOException {
         List<AffinityLock> locks = new LinkedList<>();

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.text.html.parser.Parser;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,7 +49,7 @@ public class AffinityLockTest extends BaseAffinityTest {
 
     @Test
     public void dumpLocksI7() throws IOException {
-        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("i7.cpuinfo"), IsolateConfigurationFactory.EMPTY);
+        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("i7.cpuinfo"), IsolateConfigurationFactory.EMPTY_CONFIGURATION);
         AffinityLock[] locks = {
                 new AffinityLock(0, true, false, lockInventory),
                 new AffinityLock(1, false, false, lockInventory),
@@ -87,7 +86,7 @@ public class AffinityLockTest extends BaseAffinityTest {
 
     @Test
     public void dumpLocksI3() throws IOException {
-        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("i3.cpuinfo"), IsolateConfigurationFactory.EMPTY);
+        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("i3.cpuinfo"), IsolateConfigurationFactory.EMPTY_CONFIGURATION);
         AffinityLock[] locks = {
                 new AffinityLock(0, true, false, lockInventory),
                 new AffinityLock(1, false, true, lockInventory),
@@ -110,7 +109,7 @@ public class AffinityLockTest extends BaseAffinityTest {
 
     @Test
     public void dumpLocksCoreDuo() throws IOException {
-        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("core.duo.cpuinfo"), IsolateConfigurationFactory.EMPTY);
+        LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("core.duo.cpuinfo"), IsolateConfigurationFactory.EMPTY_CONFIGURATION);
         AffinityLock[] locks = {
                 new AffinityLock(0, true, false, lockInventory),
                 new AffinityLock(1, false, true, lockInventory),
@@ -314,7 +313,7 @@ public class AffinityLockTest extends BaseAffinityTest {
     }
 
     @Test
-    public void cannotReserveNonIsolatedCpu() throws IOException {
+    public void cannotReserveNonIsolatedCpu() throws IOException, IsolateConfigurationParser.ParseException {
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream("isolate/isolate.i7.ini");
         IsolateConfigurationParser parser = new IsolateConfigurationParser();
         LockInventory lockInventory = new LockInventory(VanillaCpuLayout.fromCpuInfo("i7.cpuinfo"), parser.parse(inputStream));

--- a/affinity/src/test/java/net/openhft/affinity/BaseAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/BaseAffinityTest.java
@@ -38,7 +38,7 @@ public class BaseAffinityTest {
     @After
     public void restoreTmpDirectoryAndReleaseAllLocks() {
         // don't leave any locks locked
-        for (int i = 0; i < AffinityLock.PROCESSORS; i++) {
+        for (int i = 0; i < TestUtil.processorCount(); i++) {
             LockCheck.releaseLock(i);
         }
         System.setProperty("java.io.tmpdir", originalTmpDir);

--- a/affinity/src/test/java/net/openhft/affinity/TestUtil.java
+++ b/affinity/src/test/java/net/openhft/affinity/TestUtil.java
@@ -1,0 +1,20 @@
+package net.openhft.affinity;
+
+import net.openhft.affinity.impl.VanillaCpuLayout;
+
+import java.io.IOException;
+
+public final class TestUtil {
+
+    private TestUtil() {
+    }
+
+    public static int processorCount() {
+        try {
+            return VanillaCpuLayout.fromCpuInfo().cpus();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactoryTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationFactoryTest.java
@@ -1,0 +1,52 @@
+package net.openhft.affinity.impl.isolate;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+public class IsolateConfigurationFactoryTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @After
+    public void after() {
+        // Clear this after each test to prevent test bleed
+        System.clearProperty(IsolateConfigurationFactory.ISOLATE_INI_PATH_OVERRIDE_PROPERTY);
+    }
+
+    @Test
+    public void fileNotFound() {
+        setIniPath(Paths.get(temporaryFolder.toString(), "does-not-exist").toString());
+
+        IsolateConfiguration config = IsolateConfigurationFactory.load();
+        assertEquals(IsolateConfigurationFactory.EMPTY_CONFIGURATION, config);
+    }
+
+    @Test
+    public void parseError() throws IOException {
+        File file = temporaryFolder.newFile("test.ini");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+        writer.write("[isolate]");
+        writer.newLine();
+        writer.write("cpu=!&^#");
+        setIniPath(Paths.get(temporaryFolder.toString(), "test.ini").toString());
+
+        IsolateConfiguration config = IsolateConfigurationFactory.load();
+        assertEquals(IsolateConfigurationFactory.EMPTY_CONFIGURATION, config);
+    }
+
+    private static void setIniPath(String iniPath) {
+        System.setProperty(IsolateConfigurationFactory.ISOLATE_INI_PATH_OVERRIDE_PROPERTY, iniPath);
+    }
+
+}

--- a/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParserTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParserTest.java
@@ -1,0 +1,45 @@
+package net.openhft.affinity.impl.isolate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IsolateConfigurationParserTest {
+
+    private IsolateConfigurationParser parser;
+
+    @Before
+    public void before() {
+        parser = new IsolateConfigurationParser();
+    }
+
+    @Test
+    public void parseWellFormed() {
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream("isolate/isolate.ini");
+        IsolateConfigurationParser parser = new IsolateConfigurationParser();
+        IsolateConfiguration config = parser.parse(inputStream);
+        assertEquals(8, config.isolatedCpus().size());
+        assertTrue(config.isolatedCpus().contains(1));
+        assertTrue(config.isolatedCpus().contains(2));
+        assertTrue(config.isolatedCpus().contains(3));
+        assertTrue(config.isolatedCpus().contains(4));
+        assertTrue(config.isolatedCpus().contains(5));
+        assertTrue(config.isolatedCpus().contains(6));
+        assertTrue(config.isolatedCpus().contains(7));
+        assertTrue(config.isolatedCpus().contains(10));
+    }
+
+    @Test
+    public void malformedInput() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("cpus=!".getBytes(StandardCharsets.UTF_8));
+        IsolateConfiguration config = parser.parse(inputStream);
+        assertEquals(0, config.isolatedCpus().size());
+    }
+
+}

--- a/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParserTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/isolate/IsolateConfigurationParserTest.java
@@ -35,6 +35,24 @@ public class IsolateConfigurationParserTest {
     }
 
     @Test
+    public void parseSingle() throws ParseException {
+        IsolateConfiguration config = parser.parse(createCpuInput("1"));
+        assertThat(config.isolatedCpus(), hasItems(1));
+    }
+
+    @Test
+    public void parseRange() throws ParseException {
+        IsolateConfiguration config = parser.parse(createCpuInput("1-2"));
+        assertThat(config.isolatedCpus(), hasItems(1, 2));
+    }
+
+    @Test
+    public void parseTwoRanges() throws ParseException {
+        IsolateConfiguration config = parser.parse(createCpuInput("1-2,6-8"));
+        assertThat(config.isolatedCpus(), hasItems(1, 2, 6, 8));
+    }
+
+    @Test
     public void parseFailureSingleCpu() {
         ParseException exception = assertThrows(ParseException.class, () -> parser.parse(createCpuInput("!")));
         assertThat(exception.getMessage(), containsString("Could not parse ! as an integer"));

--- a/affinity/src/test/resources/isolate/isolate.i7.ini
+++ b/affinity/src/test/resources/isolate/isolate.i7.ini
@@ -1,0 +1,2 @@
+[isolate]
+cpus = 1-2

--- a/affinity/src/test/resources/isolate/isolate.ini
+++ b/affinity/src/test/resources/isolate/isolate.ini
@@ -1,0 +1,2 @@
+[isolate]
+cpus = 1-7,10


### PR DESCRIPTION
Integrates Affinity with Chronicle Tune isolate configuration so that Affinity plays nicely with Tune out of the box. With this change, if isolate is installed and cores isolated only cores that are isolated will be eligible for pinning. Please take a look and let me know your thoughts.