### PR TITLE
Align snapshot versions 3.26ea4-SNAPSHOT

### DIFF
--- a/affinity/pom.xml
+++ b/affinity/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>affinity</artifactId>
-    <version>3.26ea4</version>
+    <version>3.26ea4-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>OpenHFT/Java-Thread-Affinity/affinity</name>


### PR DESCRIPTION
Seems the versions are mismatched inside the affinity project itself, some modules are versioned as concrete versions, others as snapshot, they all need to be aligned on the same snapshot.

This PR sets all submodule versions to 3.26ea4-SNAPSHOT:

**Before**

```bash
Java-Thread-Affinity on  develop is 📦 v3.26ea4-SNAPSHOT via ☕ v1.8.0 
❯ egrep 3.26ea4 pom.xml */pom.xml | grep -v tag
pom.xml:    <version>3.26ea4-SNAPSHOT</version>
affinity/pom.xml:    <version>3.26ea4</version>
affinity-test/pom.xml:    <version>3.26ea4-SNAPSHOT</version>
```

**After**

```bash
Java-Thread-Affinity on  feature/align_versions_to_snapshot is 📦 v3.26ea4-SNAPSHOT via ☕ v1.8.0 
❯ egrep 3.26ea4 pom.xml */pom.xml | grep -v tag
pom.xml:    <version>3.26ea4-SNAPSHOT</version>
affinity/pom.xml:    <version>3.26ea4-SNAPSHOT</version>
affinity-test/pom.xml:    <version>3.26ea4-SNAPSHOT</version>
```