### PR TITLE
Add OSGi bundle deployment instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -249,3 +249,17 @@ try (AffinityLock lock = AffinityLock.acquireLock("0")) { // prints a warning
     assertFalse(lock.bound);
 }
 ----
+
+== Deploying the OSGi Bundle
+
+The ``affinity-test`` module is packaged as an OSGi ``bundle``. Build it with
+
+[source,bash]
+----
+mvn -pl affinity-test clean package
+----
+
+The resulting JAR can be deployed to your OSGi runtime (e.g. Apache Felix or
+Equinox) by copying it into the framework's ``bundle`` directory or by using the
+``install`` and ``start`` commands. For a reference example, see
+``affinity-test/src/test/java/net/openhft/affinity/osgi/OSGiBundleTest.java``.


### PR DESCRIPTION
## Summary
- document how to build and deploy the affinity-test bundle
- reference `OSGiBundleTest` for an example

## Testing
- `mvn -pl affinity-test test` *(fails: `mvn` not found)*