### PR TITLE
Update README with Windows JNA instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,12 @@ for the artifacts `jna` and `jna-platform` in the project's `pom` file.
 
     sudo yum install jna
 
+=== Installing JNA on Windows
+
+    choco install jna
+
+Or download jna.jar and jna-platform.jar from the JNA project and add them to your classpath.
+
 === How does CPU allocation work?
 The library will read your `/proc/cpuinfo` if you have one or provide one and it will determine your CPU layout.  If you don't have one it will assume every CPU is on one CPU socket.
 


### PR DESCRIPTION
## Summary
- document how to install JNA on Windows using Chocolatey
- mention manual download option

## Testing
- `mvn -q test` *(fails: `mvn` not found)*