### PR TITLE
Add validation for cpuId range

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -178,6 +178,9 @@ public class AffinityLock implements Closeable {
      * @return A handle for an affinity lock.
      */
     public static AffinityLock acquireLock(int cpuId) {
+        if (cpuId < 0 || cpuId >= PROCESSORS) {
+            throw new IllegalArgumentException("cpuId must be between 0 and " + (PROCESSORS - 1) + ": " + cpuId);
+        }
         return acquireLock(true, cpuId, AffinityStrategies.ANY);
     }
 
@@ -192,6 +195,9 @@ public class AffinityLock implements Closeable {
      */
     public static AffinityLock acquireLock(int[] cpus) {
         for (int cpu : cpus) {
+            if (cpu < 0 || cpu >= PROCESSORS) {
+                throw new IllegalArgumentException("cpuId must be between 0 and " + (PROCESSORS - 1) + ": " + cpu);
+            }
             AffinityLock lock = tryAcquireLock(true, cpu);
             if (lock != null) {
                 LOGGER.info("Acquired lock on CPU {}", cpu);

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
@@ -300,18 +300,14 @@ public class AffinityLockTest extends BaseAffinityTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testTooHighCpuId() {
-        try (AffinityLock ignored = AffinityLock.acquireLock(123456)) {
-            assertNotNull(ignored);
-        }
+        AffinityLock.acquireLock(123456);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testTooHighCpuId2() {
-        try (AffinityLock ignored = AffinityLock.acquireLock(new int[] {123456})) {
-            assertNotNull(ignored);
-        }
+        AffinityLock.acquireLock(new int[] {123456});
     }
 
     /**


### PR DESCRIPTION
## Summary
- validate `cpuId` arguments against `PROCESSORS`
- enforce same check when passing an array of cpuIds
- update tests to expect IllegalArgumentException for invalid ids

## Testing
- `mvn test` *(fails: mvn not found)*