### PR TITLE
Replace System.err with logger warning

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -271,7 +271,7 @@ public class AffinityLock implements Closeable {
             }
         }
         if (cpuId <= 0) {
-            System.err.println("Cannot allocate 0 or negative cpuIds '" + desc + "'");
+            LOGGER.warn("Cannot allocate 0 or negative cpuIds '{}'", desc);
             return LOCK_INVENTORY.noLock();
         }
         return acquireLock(cpuId);


### PR DESCRIPTION
## Summary
- use `LOGGER.warn` instead of `System.err.println` for invalid CPU id warning

## Testing
- `mvn -q test` *(fails: `mvn` not found)*