### PR TITLE
Fix log strings for JNI/JNA availability

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/impl/NullAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/NullAffinity.java
@@ -38,7 +38,7 @@ public enum NullAffinity implements IAffinity {
 
     @Override
     public void setAffinity(final BitSet affinity) {
-        LOGGER.trace("unable to set mask to {} as the JNIa nd JNA libraries and not loaded", Utilities.toHexString(affinity));
+        LOGGER.trace("unable to set mask to {} as the JNI and JNA libraries not loaded", Utilities.toHexString(affinity));
     }
 
     @Override

--- a/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
@@ -45,7 +45,7 @@ public enum OSXJNAAffinity implements IAffinity {
 
     @Override
     public void setAffinity(final BitSet affinity) {
-        LOGGER.trace("unable to set mask to {} as the JNIa nd JNA libraries and not loaded", Utilities.toHexString(affinity));
+        LOGGER.trace("unable to set mask to {} as the JNI and JNA libraries not loaded", Utilities.toHexString(affinity));
     }
 
     @Override

--- a/affinity/src/main/java/net/openhft/affinity/impl/SolarisJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/SolarisJNAAffinity.java
@@ -45,7 +45,7 @@ public enum SolarisJNAAffinity implements IAffinity {
 
     @Override
     public void setAffinity(final BitSet affinity) {
-        LOGGER.trace("unable to set mask to {} as the JNIa nd JNA libraries and not loaded", Utilities.toHexString(affinity));
+        LOGGER.trace("unable to set mask to {} as the JNI and JNA libraries not loaded", Utilities.toHexString(affinity));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- correct wording in log messages when JNI/JNA are not loaded

## Testing
- `mvn test` *(fails: `mvn` not found)*