### PR TITLE
Add test for negative CPU id acquisition

### DIFF
--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
@@ -325,6 +325,11 @@ public class AffinityLockTest extends BaseAffinityTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testNegativeCpuId() {
+        AffinityLock.acquireLock(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testTooHighCpuId2() {
         AffinityLock.acquireLock(new int[]{123456});
     }


### PR DESCRIPTION
## Summary
- add a unit test verifying that `AffinityLock.acquireLock(-1)` throws an IllegalArgumentException

## Testing
- `mvn test` *(fails: command not found)*