### PR TITLE
Add multi-thread dumpLocks test

### DIFF
--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockDumpLocksTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockDumpLocksTest.java
@@ -1,0 +1,54 @@
+package net.openhft.affinity;
+
+import net.openhft.affinity.impl.VanillaCpuLayout;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class AffinityLockDumpLocksTest extends BaseAffinityTest {
+
+    @Test
+    public void dumpLocksListsThreadsHoldingLocks() throws Exception {
+        Assume.assumeTrue(new File("/proc/cpuinfo").exists());
+
+        AffinityLock.cpuLayout(VanillaCpuLayout.fromCpuInfo());
+
+        int nThreads = Math.min(3, Math.max(1, AffinityLock.PROCESSORS - 1));
+        CountDownLatch acquired = new CountDownLatch(nThreads);
+        CountDownLatch release = new CountDownLatch(1);
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < nThreads; i++) {
+            String name = "worker-" + i;
+            Thread t = new Thread(() -> {
+                try (AffinityLock lock = AffinityLock.acquireLock()) {
+                    acquired.countDown();
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }, name);
+            threads.add(t);
+            t.start();
+        }
+
+        assertTrue("threads failed to acquire locks", acquired.await(5, TimeUnit.SECONDS));
+
+        String dump = AffinityLock.dumpLocks();
+        for (Thread t : threads) {
+            assertTrue("Missing entry for " + t.getName(), dump.contains("Thread[" + t.getName()));
+        }
+
+        release.countDown();
+        for (Thread t : threads) {
+            t.join();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test `dumpLocks` when multiple threads acquire locks

## Testing
- `mvn -q -pl affinity -am test` *(fails: `mvn` not found)*