### PR TITLE
Add negative PID test

### DIFF
--- a/affinity/src/test/java/net/openhft/affinity/LockCheckTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/LockCheckTest.java
@@ -56,6 +56,11 @@ public class LockCheckTest extends BaseAffinityTest {
     }
 
     @Test
+    public void testNegativePidOnLinux() {
+        Assert.assertFalse(LockCheck.isProcessRunning(-1));
+    }
+
+    @Test
     public void testReplace() throws IOException {
         cpu++;
         Assert.assertTrue(LockCheck.isCpuFree(cpu + 1));


### PR DESCRIPTION
## Summary
- ensure LockCheck handles negative PIDs

## Testing
- `mvn -q -pl affinity -am test` *(fails: `mvn: command not found`)*