### PR TITLE
Ensure EMPTY_PID returned when lock missing

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/LockCheck.java
+++ b/affinity/src/main/java/net/openhft/affinity/LockCheck.java
@@ -78,6 +78,9 @@ public enum LockCheck {
     }
 
     public static int getProcessForCpu(int core) throws IOException {
+        if (!canOSSupportOperation())
+            return EMPTY_PID;
+
         String meta = lockChecker.getMetaInfo(core);
 
         if (meta != null && !meta.isEmpty()) {

--- a/affinity/src/test/java/net/openhft/affinity/FileLockLockCheckTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/FileLockLockCheckTest.java
@@ -96,4 +96,12 @@ public class FileLockLockCheckTest extends BaseAffinityTest {
         lockFile = lockChecker.doToFile(cpu);
         Assert.assertTrue("Lock file should be recreated", lockFile.exists());
     }
+
+    @Test
+    public void getProcessForCpuReturnsEmptyPidWhenNoFile() throws IOException {
+        int freeCpu = 99;
+        File lockFile = lockChecker.doToFile(freeCpu);
+        Assert.assertFalse(lockFile.exists());
+        Assert.assertEquals(Integer.MIN_VALUE, LockCheck.getProcessForCpu(freeCpu));
+    }
 }


### PR DESCRIPTION
## Summary
- check OS support before reading lock file
- add regression test for missing lock file

## Testing
- `mvn test` *(fails: `mvn: command not found`)*