### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,4 +1,4 @@
-== Copyright 2016-2025 chronicle.software
+== Copyright 2016-2026 chronicle.software
 
 Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.

--- a/affinity-test/pom.xml
+++ b/affinity-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/affinity-test/pom.xml
+++ b/affinity-test/pom.xml
@@ -23,6 +23,7 @@
     <description>Java Thread Affinity library</description>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.line.coverage>0</jacoco.line.coverage>
         <jacoco.branch.coverage>0</jacoco.branch.coverage>
@@ -201,4 +202,3 @@
   </scm>
 
 </project>
-

--- a/affinity-test/src/main/java/net/openhft/affinity/osgi/OSGiPlaceholder.java
+++ b/affinity-test/src/main/java/net/openhft/affinity/osgi/OSGiPlaceholder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.osgi;
 

--- a/affinity-test/src/test/java/net/openhft/affinity/osgi/OSGiBundleTest.java
+++ b/affinity-test/src/test/java/net/openhft/affinity/osgi/OSGiBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.osgi;
 

--- a/affinity-test/src/test/java/net/openhft/affinity/osgi/OSGiTestBase.java
+++ b/affinity-test/src/test/java/net/openhft/affinity/osgi/OSGiTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.osgi;
 

--- a/affinity/pom.xml
+++ b/affinity/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/affinity/pom.xml
+++ b/affinity/pom.xml
@@ -23,6 +23,7 @@
     <description>Java Thread Affinity library</description>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <native.source.dir>src/main/c</native.source.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.line.coverage>0.40</jacoco.line.coverage>

--- a/affinity/src/main/c/net_openhft_ticker_impl_JNIClock.cpp
+++ b/affinity/src/main/c/net_openhft_ticker_impl_JNIClock.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/affinity/src/main/c/software_chronicle_enterprise_internals_impl_NativeAffinity.cpp
+++ b/affinity/src/main/c/software_chronicle_enterprise_internals_impl_NativeAffinity.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -114,4 +114,3 @@ JNIEXPORT jint JNICALL Java_software_chronicle_enterprise_internals_impl_NativeA
   return (jint) sched_getcpu();
 #endif
 }
-

--- a/affinity/src/main/c/software_chronicle_enterprise_internals_impl_NativeAffinity_MacOSX.c
+++ b/affinity/src/main/c/software_chronicle_enterprise_internals_impl_NativeAffinity_MacOSX.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 #include <jni.h>
 #include <mach/thread_policy.h>

--- a/affinity/src/main/java/net/openhft/affinity/Affinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/Affinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/AffinityStrategies.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/AffinityStrategy.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/AffinityThreadFactory.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/BootClassPath.java
+++ b/affinity/src/main/java/net/openhft/affinity/BootClassPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/CpuLayout.java
+++ b/affinity/src/main/java/net/openhft/affinity/CpuLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/IAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/IAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/LockCheck.java
+++ b/affinity/src/main/java/net/openhft/affinity/LockCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/LockInventory.java
+++ b/affinity/src/main/java/net/openhft/affinity/LockInventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/MicroJitterSampler.java
+++ b/affinity/src/main/java/net/openhft/affinity/MicroJitterSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/LinuxHelper.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/LinuxHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/LinuxJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/LinuxJNAAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/NoCpuLayout.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/NoCpuLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/NullAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/NullAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/OSXJNAAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/PosixJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/PosixJNAAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/SolarisJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/SolarisJNAAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/Utilities.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/VanillaCpuLayout.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/VanillaCpuLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/VersionHelper.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/VersionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/impl/WindowsJNAAffinity.java
+++ b/affinity/src/main/java/net/openhft/affinity/impl/WindowsJNAAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/main/java/net/openhft/affinity/lockchecker/FileLockBasedLockChecker.java
+++ b/affinity/src/main/java/net/openhft/affinity/lockchecker/FileLockBasedLockChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.lockchecker;
 

--- a/affinity/src/main/java/net/openhft/affinity/lockchecker/LockChecker.java
+++ b/affinity/src/main/java/net/openhft/affinity/lockchecker/LockChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.lockchecker;
 

--- a/affinity/src/main/java/net/openhft/affinity/lockchecker/LockReference.java
+++ b/affinity/src/main/java/net/openhft/affinity/lockchecker/LockReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.lockchecker;
 

--- a/affinity/src/main/java/net/openhft/affinity/main/AffinityTestMain.java
+++ b/affinity/src/main/java/net/openhft/affinity/main/AffinityTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.main;
 

--- a/affinity/src/main/java/net/openhft/ticker/ITicker.java
+++ b/affinity/src/main/java/net/openhft/ticker/ITicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.ticker;
 

--- a/affinity/src/main/java/net/openhft/ticker/Ticker.java
+++ b/affinity/src/main/java/net/openhft/ticker/Ticker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.ticker;
 

--- a/affinity/src/main/java/net/openhft/ticker/impl/JNIClock.java
+++ b/affinity/src/main/java/net/openhft/ticker/impl/JNIClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.ticker.impl;
 

--- a/affinity/src/main/java/net/openhft/ticker/impl/SystemClock.java
+++ b/affinity/src/main/java/net/openhft/ticker/impl/SystemClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.ticker.impl;
 

--- a/affinity/src/main/java/software/chronicle/enterprise/internals/impl/NativeAffinity.java
+++ b/affinity/src/main/java/software/chronicle/enterprise/internals/impl/NativeAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package software.chronicle.enterprise.internals.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockBindMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockBindMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockDumpLocksTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockDumpLocksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockReleaseTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockReleaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityResetToBaseAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityResetToBaseAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinitySupportMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinitySupportMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryMain.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/AffinityThreadFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/BaseAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/BaseAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/BootClassPathTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/BootClassPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/FileLockLockCheckTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/FileLockLockCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/InterrupedThread.java
+++ b/affinity/src/test/java/net/openhft/affinity/InterrupedThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/LockCheckTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/LockCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/MultiProcessAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/MultiProcessAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/AbstractAffinityImplTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/AbstractAffinityImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/CpuInfoLayoutMappingTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/CpuInfoLayoutMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/LinuxJNAAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/LinuxJNAAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/NativeAffinityImpTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/NativeAffinityImpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/PosixJNAAffinityTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/PosixJNAAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/UtilitiesTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/UtilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutPairTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutPropertiesParseTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutPropertiesParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/VanillaCpuLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/impl/VersionHelperTest.java
+++ b/affinity/src/test/java/net/openhft/affinity/impl/VersionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.impl;
 

--- a/affinity/src/test/java/net/openhft/affinity/testimpl/TestFileLockBasedLockChecker.java
+++ b/affinity/src/test/java/net/openhft/affinity/testimpl/TestFileLockBasedLockChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.affinity.testimpl;
 

--- a/affinity/src/test/java/net/openhft/ticker/impl/JNIClockTest.java
+++ b/affinity/src/test/java/net/openhft/ticker/impl/JNIClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.ticker.impl;
 

--- a/affinity/src/test/java/software/chronicle/enterprise/internals/JnaAffinityTest.java
+++ b/affinity/src/test/java/software/chronicle/enterprise/internals/JnaAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package software.chronicle.enterprise.internals;
 

--- a/affinity/src/test/java/software/chronicle/enterprise/internals/NativeAffinityTest.java
+++ b/affinity/src/test/java/software/chronicle/enterprise/internals/NativeAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package software.chronicle.enterprise.internals;
 

--- a/affinity/src/test/resources/dual.E5405.properties
+++ b/affinity/src/test/resources/dual.E5405.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 chronicle.software
+# Copyright 2016-2026 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/affinity/src/test/resources/dual.xeon.properties
+++ b/affinity/src/test/resources/dual.xeon.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 chronicle.software
+# Copyright 2016-2026 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/affinity/src/test/resources/i3.properties
+++ b/affinity/src/test/resources/i3.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 chronicle.software
+# Copyright 2016-2026 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/affinity/src/test/resources/i7.properties
+++ b/affinity/src/test/resources/i7.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 chronicle.software
+# Copyright 2016-2026 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,10 @@
     <name>OpenHFT/Java-Thread-Affinity Parent</name>
     <description>Java Thread Affinity library</description>
 
+    <properties>
+        <license.year>2013-2026</license.year>
+    </properties>
+
     <modules>
         <module>affinity</module>
         <module>affinity-test</module>


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds local `license.year=2013-2026` overrides in the project POMs so `license-maven-plugin` validates the updated headers correctly on CI across the multi-module build.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM overrides.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)