### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -4,7 +4,7 @@ Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.adoc
+++ b/README.adoc
@@ -314,7 +314,7 @@ System.out.println("\nThe assignment of CPUs is\n" + AffinityLock.dumpLocks());
 
 https://groups.google.com/forum/?hl=en-GB#!forum/java-thread-affinity[Java Thread Affinity support group]
 
-For an article on how much difference affinity can make and how to use it http://vanillajava.blogspot.com/2013/07/micro-jitter-busy-waiting-and-binding.html
+For an article on how much difference affinity can make and how to use it https://vanillajava.blogspot.com/2013/07/micro-jitter-busy-waiting-and-binding.html
 
 == Questions and Answers
 


### PR DESCRIPTION
Superseded by #198. Its consolidated README change uses the verified current Vanilla Java article address, alongside the Maven badge and examples-link repairs. The optional Apache licence protocol edit from this PR was omitted.
