### PR TITLE
docs: repair Affinity version, examples and article links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ image::docs/images/Thread-Affinity_line.png[width=20%]
 
 [#image-maven]
 [caption="",link=https://central.sonatype.com/artifact/net.openhft/affinity]
-image::https://img.shields.io/maven-central/v/net.openhft/affinity.svg[]
+image::https://img.shields.io/maven-central/v/net.openhft/affinity.svg[Maven Central]
 image:https://javadoc.io/badge2/net.openhft/affinity/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/affinity/latest/index.html"]
 
 == Overview
@@ -14,7 +14,7 @@ Lets you bind a thread to a given core, this can improve performance (this libra
 
 OpenHFT Java Thread Affinity library
 
-See https://github.com/OpenHFT/Java-Thread-Affinity/tree/master/affinity/src/test/java[affinity/src/test/java]
+See https://github.com/OpenHFT/Java-Thread-Affinity/tree/develop/affinity/src/test/java[affinity/src/test/java]
 for working examples of how to use this library.
 
 === Supported operating systems
@@ -314,7 +314,7 @@ System.out.println("\nThe assignment of CPUs is\n" + AffinityLock.dumpLocks());
 
 https://groups.google.com/forum/?hl=en-GB#!forum/java-thread-affinity[Java Thread Affinity support group]
 
-For an article on how much difference affinity can make and how to use it http://vanillajava.blogspot.com/2013/07/micro-jitter-busy-waiting-and-binding.html
+For an article on how much difference affinity can make and how to use it https://blog.vanillajava.blog/2013/07/micro-jitter-busy-waiting-and-binding.html
 
 == Questions and Answers
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,8 +5,8 @@ image::docs/images/Thread-Affinity_line.png[width=20%]
 == Version
 
 [#image-maven]
-[caption="",link=https://maven-badges.herokuapp.com/maven-central/net.openhft/affinity]
-image::https://maven-badges.herokuapp.com/maven-central/net.openhft/affinity/badge.svg[]
+[caption="",link=https://central.sonatype.com/artifact/net.openhft/affinity]
+image::https://img.shields.io/maven-central/v/net.openhft/affinity.svg[]
 image:https://javadoc.io/badge2/net.openhft/affinity/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/affinity/latest/index.html"]
 
 == Overview


### PR DESCRIPTION
Repair three README destinations in one change:

- Use [Shields' Maven Central API](https://shields.io/badges/maven-central-version) with a Maven Central label and a link to [net.openhft:affinity](https://central.sonatype.com/artifact/net.openhft/affinity). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.
- Restore access to [the examples on develop](https://github.com/OpenHFT/Java-Thread-Affinity/tree/develop/affinity/src/test/java), replacing the absent master target from #199. The repository default is `ea`; `develop` is the verified examples target.
- Use [the current Vanilla Java article address](https://blog.vanillajava.blog/2013/07/micro-jitter-busy-waiting-and-binding.html), incorporating the useful article-link work from #197.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The examples directory exists on the fetched develop revision, and the article returned HTTP 200 with the expected title. The complete change is four README lines; Java tests were not rerun for these documentation edits.
