### PR TITLE
docs: update stale GitHub branch references (master -> develop/ea)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ Lets you bind a thread to a given core, this can improve performance (this libra
 
 OpenHFT Java Thread Affinity library
 
-See https://github.com/OpenHFT/Java-Thread-Affinity/tree/master/affinity/src/test/java[affinity/src/test/java]
+See https://github.com/OpenHFT/Java-Thread-Affinity/tree/develop/affinity/src/test/java[affinity/src/test/java]
 for working examples of how to use this library.
 
 === Supported operating systems


### PR DESCRIPTION
Superseded by #198, which includes this repair to the examples link. The develop examples directory exists; the repository default branch is ea, correcting the earlier description's claim that develop was the default.
