### PR TITLE
docs: fix common typos

### DIFF
--- a/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
+++ b/affinity/src/main/java/net/openhft/affinity/AffinityLock.java
@@ -456,7 +456,7 @@ public class AffinityLock implements Closeable {
     }
 
     /**
-     * @return unique id for this CPI or -1 if not allocated.
+     * @return unique id for this CPU or -1 if not allocated.
      */
     public int cpuId() {
         return cpuId;


### PR DESCRIPTION
## Summary
Typo fixes covering: `locaiton`, `receieved`, `visibe`, `receipient`, `Signtaure`, `signatire`, `extenstions`, `diabled`, `overriden`, `sl4j`, `andd`, `resuable`, `endian-independant`, `benchamrk`, `by used`/`will replaced`, and the `CPI` -> `CPU` slip in AffinityLock javadoc.

Doc-only - no behaviour changes.

## Test plan
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)