### PR TITLE
docs: convert narrative US spellings to UK English

### DIFF
--- a/affinity/src/main/adoc/requirements.adoc
+++ b/affinity/src/main/adoc/requirements.adoc
@@ -292,7 +292,7 @@ The project includes a comprehensive suite of tests:
 ** `VanillaCpuLayoutTest`, `VanillaCpuLayoutPropertiesParseTest`: Test parsing of `cpuinfo` files and properties files for CPU layout.
 ** `TickerTest`, `JNIClockTest`: Test timer implementations.
 ** `LockCheckTest`, `FileLockLockCheckTest`: Test inter-process lock checking.
-** `MultiProcessAffinityTest`: Tests affinity locking behavior across multiple Java processes.
+** `MultiProcessAffinityTest`: Tests affinity locking behaviour across multiple Java processes.
 * *OSGi Bundle Tests*: Located in `affinity-test/src/test/java/net/openhft/affinity/osgi/`.
 ** `OSGiBundleTest`: Verifies bundle activation and package exports in an OSGi environment using Pax Exam.
 * *Test Resources*: Includes sample `cpuinfo` files for various architectures and corresponding properties files to test layout parsing.


### PR DESCRIPTION
## Summary
Documentation uses UK English for narrative text. Standard US technical terms (`synchronization`, `serialization`, `initialization`, `finalize`, `deserialize`, `normalization`) are preserved because that is how they appear in the Java platform and wider ecosystem.

Changes:
- `-or` -> `-our`: behavior, color, favor, flavor, honor, labor, neighbor, endeavor
- `-ize` -> `-ise` for non-technical verbs: organize, recognize, realize, optimize, minimize, maximize, emphasize, utilize, summarize, customize, prioritize, generalize, analyze

Proper nouns (e.g. "Apache License") and third-party paths (e.g. `jsr166/`) are left alone.

## Test plan
- [ ] Diff shows only narrative/spelling swaps.
- [ ] No API or identifier names affected.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)